### PR TITLE
additional directory settings and units for heap size

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -50,7 +50,11 @@ class neo4j::config (
   $dbms_directories_certificates = $neo4j::dbms_directories_certificates
   $dbms_directories_data         = $neo4j::dbms_directories_data
   $dbms_directories_import       = $neo4j::dbms_directories_import
+  $dbms_directories_lib          = $neo4j::dbms_directories_lib
+  $dbms_directories_logs         = $neo4j::dbms_directories_logs
+  $dbms_directories_metrics      = $neo4j::dbms_directories_metrics
   $dbms_directories_plugins      = $neo4j::dbms_directories_plugins
+  $dbms_directories_run          = $neo4j::dbms_directories_run
   $dbms_memory_pagecache_size    = $neo4j::dbms_memory_pagecache_size
   $dbms_security_auth_enabled    = $neo4j::dbms_security_auth_enabled
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,7 +27,11 @@
 # [*dbms_directories_certificates*]
 # [*dbms_directories_data*]
 # [*dbms_directories_import*]
+# [*dbms_directories_lib*]
+# [*dbms_directories_logs*]
+# [*dbms_directories_metrics*]
 # [*dbms_directories_plugins*]
+# [*dbms_directories_run*]
 # [*dbms_ids_reuse_types_override*]
 # [*dbms_jvm_additional_commit_memory_to_process*]
 # [*dbms_jvm_additional_disable_explicit_gc*]
@@ -150,7 +154,11 @@ class neo4j (
   $dbms_directories_certificates                      = $neo4j::params::dbms_directories_certificates,
   $dbms_directories_data                              = $neo4j::params::dbms_directories_data,
   $dbms_directories_import                            = $neo4j::params::dbms_directories_import,
+  $dbms_directories_lib                               = $neo4j::params::dbms_directories_lib,
+  $dbms_directories_logs                              = $neo4j::params::dbms_directories_logs,
+  $dbms_directories_metrics                           = $neo4j::params::dbms_directories_metrics,
   $dbms_directories_plugins                           = $neo4j::params::dbms_directories_plugins,
+  $dbms_directories_run                               = $neo4j::params::dbms_directories_run,
   $dbms_memory_pagecache_size                         = $neo4j::params::dbms_memory_pagecache_size,
   $dbms_security_auth_enabled                         = $neo4j::params::dbms_security_auth_enabled,
 
@@ -275,13 +283,14 @@ class neo4j (
     $dbms_logs_http_rotation_keep_number,
     $dbms_logs_query_rotation_keep_number,
     $dbms_logs_query_threshold,
-    $dbms_memory_heap_initial_size,
-    $dbms_memory_heap_max_size,
     $dbms_shell_port,
     $ha_pull_interval,
     $service_shutdown_timeout,
     $service_ulimit,
   ])
+
+  validate_re( $dbms_memory_heap_initial_size, '[1-9][0-9]*(k|m|g|K|M|G)?', 'size should be an integer followed by a scalar (k|m|g|K|M|G)' )
+  validate_re( $dbms_memory_heap_max_size, '[1-9][0-9]*(k|m|g|K|M|G)?', 'size should be an integer followed by a scalar (k|m|g|K|M|G)' )
 
   validate_re( $ha_join_timeout, '[1-9][0-9]*(ms|s|m)?' )
 
@@ -292,7 +301,11 @@ class neo4j (
     $dbms_directories_certificates,
     $dbms_directories_data,
     $dbms_directories_import,
+    $dbms_directories_lib,
+    $dbms_directories_logs,
+    $dbms_directories_metrics,
     $dbms_directories_plugins,
+    $dbms_directories_run,
     $dbms_mode,
     $dbms_tx_log_rotation_retention_policy,
     $group,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,10 +20,6 @@ class neo4j::params {
   $dbms_connector_https_enabled                       = true
   $dbms_connector_https_encryption                    = 'TLS'
   $dbms_connector_https_port                          = 7473
-  $dbms_directories_certificates                      = 'certificates'
-  $dbms_directories_data                              = 'data'
-  $dbms_directories_import                            = 'import'
-  $dbms_directories_plugins                           = 'plugins'
   $dbms_ids_reuse_types_override                      = [ 'node',
                                                           'relationship'
                                                         ]
@@ -61,8 +57,8 @@ class neo4j::params {
   $dbms_logs_query_rotation_keep_number               = 7
   $dbms_logs_query_rotation_size                      = '20m'
   $dbms_logs_query_threshold                          = 0
-  $dbms_memory_heap_initial_size                      = 512
-  $dbms_memory_heap_max_size                          = 512
+  $dbms_memory_heap_initial_size                      = '512m'
+  $dbms_memory_heap_max_size                          = '512m'
   $dbms_memory_pagecache_size                         = '10g'
   $dbms_mode                                          = 'HA'
   $dbms_read_only                                     = false
@@ -106,14 +102,30 @@ class neo4j::params {
   $user                                               = 'neo4j'
   case $::osfamily {
     'RedHat': {
-      $default_file     = '/etc/sysconfig/neo4j'
-      $service_provider = 'redhat'
-      $version          = 'installed'
+      $default_file                   = '/etc/sysconfig/neo4j'
+      $service_provider               = 'redhat'
+      $version                        = 'installed'
+      $dbms_directories_certificates  = 'certificates'
+      $dbms_directories_data          = 'data'
+      $dbms_directories_import        = 'import'
+      $dbms_directories_lib           = 'lib'
+      $dbms_directories_logs          = 'logs'
+      $dbms_directories_metrics       = 'metrics'
+      $dbms_directories_plugins       = 'plugins'
+      $dbms_directories_run           = 'run'
     }
     'Debian': {
       $default_file     = '/etc/default/neo4j'
       $service_provider = 'debian'
       $version          = 'installed'
+      $dbms_directories_certificates  = '/var/lib/neo4j/certificates'
+      $dbms_directories_data          = '/var/lib/neo4j/data'
+      $dbms_directories_import        = '/var/lib/neo4j/import'
+      $dbms_directories_lib           = 'lib'
+      $dbms_directories_logs          = '/var/log/neo4j'
+      $dbms_directories_metrics       = '/var/lib/neo4j/metrics'
+      $dbms_directories_plugins       = '/var/lib/neo4j/plugins'
+      $dbms_directories_run           = '/var/run/neo4j'
     }
     default: {
       fail( "Unsupported OS family: ${::osfamily}" )

--- a/templates/neo4j.conf.general.erb
+++ b/templates/neo4j.conf.general.erb
@@ -6,6 +6,15 @@
 dbms.active_database=<%= @dbms_active_database %>
 
 # Paths of directories in the installation.
+dbms.directories.certificates=<%= @dbms_directories_certificates %>
+dbms.directories.data=<%= @dbms_directories_data %>
+dbms.directories.import=<%= @dbms_directories_import %>
+dbms.directories.lib=<%= @dbms_directories_lib %>
+dbms.directories.logs=<%= @dbms_directories_logs %>
+dbms.directories.metrics=<%= @dbms_directories_metrics %>
+dbms.directories.plugins=<%= @dbms_directories_plugins %>
+dbms.directories.run=<%= @dbms_directories_run %>
+
 dbms.directories.data=<%= @dbms_directories_data %>
 dbms.directories.plugins=<%= @dbms_directories_plugins %>
 dbms.directories.certificates=<%= @dbms_directories_certificates %>


### PR DESCRIPTION
I found that the defaults resulted in a deprecation warning that dbms_memory_heap_initial_size and ...max_size required a unit indicator (k|m|g|K|M|G).  This enforces that requirement through a regular expression validator.

I also found that the defaults yielded an unstartable instance on debian 8 because the neo4j.conf did not fully specify the file layout found on Debian hosts.  This should also resolve issue #20.