### PR TITLE
Changes Spec Error to be generic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ matrix:
   fast_finish: true
   include:
   - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3.0"
+  - rvm: 1.9.3
     env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES="yes" FUTURE_PARSER="yes"
   - rvm: 2.1.10
     env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES="yes" FUTURE_PARSER="yes"

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -307,7 +307,7 @@ describe 'neo4j::service' do
             user: 'neo4j'
           }
         end
-        it { is_expected.to raise_error(Puppet::PreformattedError, %r{Service provider magic not supported}) }
+        it { is_expected.to raise_error(%r{Service provider magic not supported}) }
       end
     end
 


### PR DESCRIPTION
* Error type changes between Puppet versions
* Stops fails in Travis for 3.8 w/o Future Parser
* Adds test to catch non-future 3.8