### PR TITLE
Replace deprecated yum/apt repo neo4j.org with neo4j.com

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -52,22 +52,22 @@ class neo4j::install (
           'RedHat': {
             yumrepo {'neo4j':
               descr    => 'Neo4j Yum Repo',
-              baseurl  => "http://yum.neo4j.org/${release_rpm}",
+              baseurl  => "http://yum.neo4j.com/${release_rpm}",
               gpgcheck => 1,
-              gpgkey   => 'http://debian.neo4j.org/neotechnology.gpg.key',
+              gpgkey   => 'http://debian.neo4j.com/neotechnology.gpg.key',
               enabled  => 1,
             }
             Yumrepo['neo4j'] -> Package['neo4j']
           }
           'Debian': {
             apt::source { 'neo4j':
-              location => 'http://debian.neo4j.org/repo',
+              location => 'http://debian.neo4j.com/repo',
               release  => "${release_deb}/",
               repos    => '',
               key      => {
                 'id'     => '66D34E951A8C53D90242132B26C95CF201182252',
                 'server' => 'pgp.mit.edu',
-                'source' => 'http://debian.neo4j.org/neotechnology.gpg.key',
+                'source' => 'http://debian.neo4j.com/neotechnology.gpg.key',
               },
             }
             Apt::Source['neo4j'] -> Package['neo4j']

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -35,7 +35,7 @@ describe 'neo4j' do
           }
           it { should contain_yumrepo('neo4j').with(
             {
-              'baseurl' => 'http://yum.neo4j.org/testing'
+              'baseurl' => 'http://yum.neo4j.com/testing'
             })
           }
         end


### PR DESCRIPTION
yum and apt repos yum.neo4j.org and debian.neo4j.org have been officially deprecated in favor of (yum|debian).neo4j.com and no longer contain the latest packages. 
This pull request replaces yum/apt location neo4j.org with neo4j.com.